### PR TITLE
Fix issue with single instance, which causes error with opening already opened app on windows

### DIFF
--- a/skeleton/app.js
+++ b/skeleton/app.js
@@ -128,21 +128,24 @@ export default class App {
     applySingleInstance() {
         if ('singleInstance' in this.settings && this.settings.singleInstance) {
             this.l.verbose('setting single instance mode');
-            const locked = app.requestSingleInstanceLock();
 
-            app.on('second-instance', () => {
-                // Someone tried to run a second instance, we should focus our window.
-                if (this.window) {
-                    if (this.window.isMinimized()) {
-                        this.window.restore();
-                    }
-                    this.window.focus();
-                }
-            });
+            const isFirstInstance = app.requestSingleInstanceLock();
 
-            if (!locked) {
+            if (!isFirstInstance) {
                 this.l.warn('current instance was terminated because another instance is running');
                 app.quit();
+            } else {
+                app.on('second-instance', () => {
+                    // Someone tried to run a second instance, we should focus our window.
+                    if (this.window) {
+                        if (this.window.isMinimized()) {
+                            this.window.restore();
+                            this.window.focus();
+                        } else {
+                            this.window.show();
+                        }
+                    }
+                });
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your interest in the project! We appreciate your submission!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

Read a guide on [opening pull requests](https://opensource.guide/how-to-contribute/#opening-a-pull-request).

-->

<!-- What changes are being made? (What feature/bug is being fixed here?)
Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
-->
## What
Fix logic of managing single instance mode which affects opening of already opened app on windows. This issue was 
<!-- Why are these changes necessary? -->
## Why
The case was tested and found by our team after updating to meteor-desktop to the new version of electron. Initialy found and fixed in https://github.com/sharekey/meteor-desktop/pull/67/files
<!-- Anything else beside this PR that needs to happen? -->
