### PR TITLE
Support for fetch added to meteor protocol.

### DIFF
--- a/skeleton/app.js
+++ b/skeleton/app.js
@@ -32,7 +32,7 @@ export default class App {
             electron.protocol.registerStandardSchemes(['meteor'], { secure: true });
         } else {
             electron.protocol.registerSchemesAsPrivileged([
-                { scheme: 'meteor', privileges: { standard: true, secure: true } }
+                { scheme: 'meteor', privileges: { standard: true, secure: true, supportFetchAPI: true } }
             ]);
         }
 


### PR DESCRIPTION
Fixes #18.

My guess is adding `supportFetchAPI` would not have any negative side effects, but maybe there's something I'm missing and should be tested by someone else. It works for me.