### PR TITLE
Fixes for devEnvSetup.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ To migrate from the original `meteor-desktop`:
 
 <sup>__*1__ you can always build with `--server-only` if you do not want to have mobile clients,  you do not actually have to have android sdk or xcode to go on with your project</sup>
 
-### Quick start
+## Quick start
 ```bash
- cd /your/meteor/app
- meteor npm install --save-dev @meteor-community/meteor-desktop
- # you need to have any mobile platform added (ios/android)
- meteor --mobile-server=127.0.0.1:3000
+cd /your/meteor/app
+meteor npm install --save-dev @meteor-community/meteor-desktop
+meteor add-platform ios # or android
+npm run desktop -- init
 
- # open new terminal
+meteor --mobile-server=127.0.0.1:3000
 
- npm run desktop -- init
- npm run desktop
-
- # or in one command `npm run desktop -- --scaffold`
+# open new terminal
+npm run desktop
 ```
+
+The first time, you can also combine `npm run desktop -- init` and `npm run desktop` into `npm run desktop -- --scaffold` once meteor is running.
 
 ## Usage `--help`
 

--- a/README.md
+++ b/README.md
@@ -601,25 +601,35 @@ Currently there are some defaults provided only for `Windows` and `Mac`. If you 
 Change `target: ["appx"]` in `win` section of `builderOptions`. In case of problems please refer to
 [electron-builder](https://github.com/electron-userland/electron-builder) documentation.
 
-##### ! devEnvSetup.js !
-To help you contribute, there is a development environment setup script. If you have this repo
-cloned and already did a `npm install`, you can just run it with `node devEnvSetup.js`.
-However if you did not yet clone this repo just do:
-```
-mkdir tmp
-cd tmp
-wget https://raw.githubusercontent.com/wojtkowiak/meteor-desktop/master/devEnvSetup.js
-npm install cross-spawn shelljs npm
+## Developing meteor-desktop
+
+No matter which method below you choose, run `npm run build-watch` in your local meteor-desktop folder before making changes to the code, if you want them reflected in Meteor apps that depend on the package.
+
+### Using devEnvSetup.js
+To help you contribute, there is a development environment setup script. It also runs default tests.
+
+This script assumes you have `npm`, `git` and `meteor` available from the command line. Note that by default, the script will install packages in the *parent* directory of where it is, so it is recommended to clone meteor-desktop inside an empty dir.
+
+```bash
+mkdir meteor-desktop-dev && cd meteor-desktop-dev
+git clone https://github.com/Meteor-Community-Packages/meteor-desktop.git
+cd meteor-desktop
+npm install
 node devEnvSetup.js
 ```
-This script assumes you have `npm`, `git` and `meteor` available from the command line.
 
-Currently this package does not work when linked with `npm link`. To set up your dev environment
-it is best to create a clean `Meteor` project, add `@meteor-community/meteor-desktop` to dependencies with a relative
- path to the place where you have cloned this repo and in scripts add `desktop` with `node
- ./path/to/meteor-desktop/dist/bin/cli.js`.  
- Also to make changes in the desktop HCP plugins run `Meteor` project with `METEOR_PACKAGE_DIRS`
- set to `/absolute/path/to/meteor-desktop/plugins` so that they will be taken from the cloned repo.
+### Without using devEnvSetup.js
+
+1. Clone and install meteor-desktop as above
+2. From a clean Meteor project, install meteor-desktop from its local folder: `meteor npm i --save-dev /path/to/meteor-desktop` (doesn't work with npm link, tbc)
+3. In your Meteor app's `package.json`:
+   1. Add a script `desktop` with `METEOR_PACKAGE_DIRS=/path/to/meteor-desktop/plugins node /path/to/meteor-desktop/dist/bin/cli.js`
+   2. Add `METEOR_PACKAGE_DIRS=/path/to/meteor-desktop/plugins` to the `start` script as well.
+
+The last step is so that the desktop HCP Meteor packages are also taken from your local meteor-desktop repo. 
+Make sure to run Meteor with `meteor npm start` rather than just `meteor`.
+
+Finally, follow the above "Quick start" steps (except the npm install) from your Meteor app.
 
 ## Built with `meteor-desktop`
 

--- a/devEnvSetup.js
+++ b/devEnvSetup.js
@@ -207,6 +207,10 @@ question('Do you want to use another path (yes/no [no])? ')
     })
     .then(function() {
         if (!runTests) return;
+        // Consider manually running `npm run test-integration` in meteor-desktop/, which also runs
+        // `desktop -- build -b` but tests its output and runs more tests. Not done automatically
+        // here because test-integration creates its own temp meteor project (a different approach
+        // to this script, which uses meteor-desktop-test-app) and overlaps this test here.
         return spawn(npm, ['run', 'desktop', '--', 'build', '-b'], path.join(resolvedPath, 'meteor-desktop-test-app'));
     })
     .then(function() {

--- a/devEnvSetup.js
+++ b/devEnvSetup.js
@@ -1,10 +1,10 @@
 require('shelljs/global');
-var path = require('path');
-var readline = require('readline');
-var fs = require('fs');
-var crossSpawn = require('cross-spawn');
+const path = require('path');
+const readline = require('readline');
+const fs = require('fs');
+const crossSpawn = require('cross-spawn');
 
-var rl;
+let rl;
 
 console.log('\n');
 console.log('┌┬┐┌─┐┌┬┐┌─┐┌─┐┬─┐  ┌┬┐┌─┐┌─┐┬┌─┌┬┐┌─┐┌─┐');
@@ -16,10 +16,10 @@ console.log('\n');
 console.log('This script will git clone other meteor-desktop related repos and create a test' +
     ' application.\n\n');
 
-var projectsDir = path.resolve('./..');
-var resolvedPath;
-var npm = 'npm'; // Or use a custom explicit path, just as path.resolve('./node_modules/.bin/npm');
-var runTests = false;
+const projectsDir = path.resolve('./..');
+const npm = 'npm'; // Or use a custom explicit path, just as path.resolve('./node_modules/.bin/npm')
+let resolvedPath;
+let runTests = false;
 
 console.log('Assuming your projects directory is: ' + projectsDir + '\n\n');
 
@@ -60,10 +60,10 @@ function finish() {
         ' options set in `settings.json` so it will also use linked plugins.');
 }
 
-var cloneMeteorDesktop = false;
-var forks = false;
-var username = '';
-var projects = [ 'meteor-desktop-test-suite', 'meteor-desktop-splash-screen' ];
+let cloneMeteorDesktop = false;
+let forks = false;
+let username = '';
+const projects = [ 'meteor-desktop-test-suite', 'meteor-desktop-splash-screen' ];
 
 question('Do you want to use another path (yes/no [no])? ')
     .then(function(answer) {
@@ -113,7 +113,7 @@ question('Do you want to use another path (yes/no [no])? ')
                 exec('git clone ' + projectRepo);
             });
         } else {
-            var code;
+            let code;
             projects.forEach(function (project) {
                 code = exec('git clone https://github.com/' + username + '/' + project).code;
                 if (code !== 0) {
@@ -175,17 +175,17 @@ question('Do you want to use another path (yes/no [no])? ')
         exec(npm + ' install --save-dev cross-env');
         exec(npm + ' install --save @babel/runtime');
         cd(resolvedPath);
-        var packageJsonPath = path.join(resolvedPath, 'meteor-desktop-test-app', 'package.json');
-        var packageJson = JSON.parse(fs.readFileSync(packageJsonPath), 'utf8');
+        const packageJsonPath = path.join(resolvedPath, 'meteor-desktop-test-app', 'package.json');
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath), 'utf8');
         packageJson.scripts.desktop = 'cross-env METEOR_PACKAGE_DIRS=' + path.join(resolvedPath, 'meteor-desktop', 'plugins') + ' node ../meteor-desktop/dist/bin/cli.js';
-        packageJson.scripts.start = 'cross-env METEOR_PACKAGE_DIRS=' + path.join(resolvedPath, 'meteor-desktop', 'plugins') + ' meteor run' ;
+        packageJson.scripts.start = 'cross-env METEOR_PACKAGE_DIRS=' + path.join(resolvedPath, 'meteor-desktop', 'plugins') + ' meteor run';
         fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
         console.log('Running npm run desktop -- init');
         exec(npm + ' run desktop -- init', { cwd: path.join(resolvedPath, 'meteor-desktop-test-app') });
 
-        var settingsJsonPath = path.join(resolvedPath, 'meteor-desktop-test-app', '.desktop', 'settings.json');
-        var settingsJson = JSON.parse(fs.readFileSync(settingsJsonPath), 'utf8');
+        const settingsJsonPath = path.join(resolvedPath, 'meteor-desktop-test-app', '.desktop', 'settings.json');
+        const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPath), 'utf8');
         settingsJson.linkPackages = ['meteor-desktop-splash-screen'];
         fs.writeFileSync(settingsJsonPath, JSON.stringify(settingsJson, null, 2));
 
@@ -216,6 +216,6 @@ question('Do you want to use another path (yes/no [no])? ')
         return spawn(npm, ['run', 'test-desktop'], path.join(resolvedPath, 'meteor-desktop-test-app'));
     })
     .then(function() {
-      finish();
+        finish();
     })
     .catch(function(e) { console.log(e); });

--- a/devEnvSetup.js
+++ b/devEnvSetup.js
@@ -65,7 +65,7 @@ var forks = false;
 var username = '';
 var projects = [ 'meteor-desktop-test-suite', 'meteor-desktop-splash-screen' ];
 
-question('Do you want to use another path (yes/no)? ')
+question('Do you want to use another path (yes/no [no])? ')
     .then(function(answer) {
         answer = answer.toLowerCase();
         if (answer === 'y' || answer === 'yes') {
@@ -193,7 +193,7 @@ question('Do you want to use another path (yes/no)? ')
     })
     .then(function() {
         console.log('\n\n\n');
-        return question('Do you want to run tests (yes/no)? ');
+        return question('Do you want to run tests (yes/no [yes])? ');
     })
     .then(function(answer) {
         answer = answer.toLowerCase();

--- a/devEnvSetup.js
+++ b/devEnvSetup.js
@@ -18,7 +18,7 @@ console.log('This script will git clone other meteor-desktop related repos and c
 
 var projectsDir = path.resolve('./..');
 var resolvedPath;
-var npm = path.resolve('./node_modules/.bin/npm');
+var npm = 'npm'; // Or use a custom explicit path, just as path.resolve('./node_modules/.bin/npm');
 
 console.log('Assuming your projects directory is: ' + projectsDir + '\n\n');
 

--- a/devEnvSetup.js
+++ b/devEnvSetup.js
@@ -19,6 +19,7 @@ console.log('This script will git clone other meteor-desktop related repos and c
 var projectsDir = path.resolve('./..');
 var resolvedPath;
 var npm = 'npm'; // Or use a custom explicit path, just as path.resolve('./node_modules/.bin/npm');
+var runTests = false;
 
 console.log('Assuming your projects directory is: ' + projectsDir + '\n\n');
 
@@ -196,21 +197,26 @@ question('Do you want to use another path (yes/no)? ')
     })
     .then(function(answer) {
         answer = answer.toLowerCase();
-        if (answer === 'n' || answer === 'no') {
-            finish();
-        }
+        runTests = (answer !== 'n' && answer !== 'no');
+    })
+    .then(function() {
+        if (!runTests) return;
         return spawn(npm, ['run', 'test'], path.join(resolvedPath, 'meteor-desktop'));
     })
     .then(function() {
+        if (!runTests) return;
         return spawn(npm, ['run', 'test'], path.join(resolvedPath, 'meteor-desktop-splash-screen'));
     })
     .then(function() {
+        if (!runTests) return;
         return spawn(npm, ['run', 'test'], path.join(resolvedPath, 'meteor-desktop-localstorage'));
     })
     .then(function() {
+        if (!runTests) return;
         return spawn(npm, ['run', 'desktop', '--', 'build', '-b'], path.join(resolvedPath, 'meteor-desktop-test-app'));
     })
     .then(function() {
+        if (!runTests) return;
         return spawn(npm, ['run', 'test-desktop'], path.join(resolvedPath, 'meteor-desktop-test-app'));
     })
     .then(function() {

--- a/devEnvSetup.js
+++ b/devEnvSetup.js
@@ -188,8 +188,6 @@ question('Do you want to use another path (yes/no [no])? ')
         const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPath), 'utf8');
         settingsJson.linkPackages = ['meteor-desktop-splash-screen'];
         fs.writeFileSync(settingsJsonPath, JSON.stringify(settingsJson, null, 2));
-
-        return spawn(npm, ['run', 'desktop', '--', 'init-tests-support'], path.join(resolvedPath, 'meteor-desktop-test-app'));
     })
     .then(function() {
         console.log('\n\n\n');
@@ -210,6 +208,10 @@ question('Do you want to use another path (yes/no [no])? ')
     .then(function() {
         if (!runTests) return;
         return spawn(npm, ['run', 'desktop', '--', 'build', '-b'], path.join(resolvedPath, 'meteor-desktop-test-app'));
+    })
+    .then(function() {
+        if (!runTests) return;
+        return spawn(npm, ['run', 'desktop', '--', 'init-tests-support'], path.join(resolvedPath, 'meteor-desktop-test-app'));
     })
     .then(function() {
         if (!runTests) return;

--- a/devEnvSetup.js
+++ b/devEnvSetup.js
@@ -209,10 +209,6 @@ question('Do you want to use another path (yes/no)? ')
     })
     .then(function() {
         if (!runTests) return;
-        return spawn(npm, ['run', 'test'], path.join(resolvedPath, 'meteor-desktop-localstorage'));
-    })
-    .then(function() {
-        if (!runTests) return;
         return spawn(npm, ['run', 'desktop', '--', 'build', '-b'], path.join(resolvedPath, 'meteor-desktop-test-app'));
     })
     .then(function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2756,23 +2756,10 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
           "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
         },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
         "emoji-regex": {
           "version": "9.2.2",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
           "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "5.1.2",
@@ -2784,57 +2771,12 @@
             "strip-ansi": "^7.0.1"
           }
         },
-        "string-width-cjs": {
-          "version": "npm:string-width@4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-            },
-            "emoji-regex": {
-              "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-            },
-            "strip-ansi": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-              "requires": {
-                "ansi-regex": "^5.0.1"
-              }
-            }
-          }
-        },
         "strip-ansi": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
           "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
           "requires": {
             "ansi-regex": "^6.0.1"
-          }
-        },
-        "strip-ansi-cjs": {
-          "version": "npm:strip-ansi@6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-            }
           }
         },
         "wrap-ansi": {
@@ -2845,54 +2787,6 @@
             "ansi-styles": "^6.1.0",
             "string-width": "^5.0.1",
             "strip-ansi": "^7.0.1"
-          }
-        },
-        "wrap-ansi-cjs": {
-          "version": "npm:wrap-ansi@7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-            },
-            "ansi-styles": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "emoji-regex": {
-              "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-            },
-            "string-width": {
-              "version": "4.2.3",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-              "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-              "requires": {
-                "ansi-regex": "^5.0.1"
-              }
-            }
           }
         }
       }
@@ -13501,6 +13395,41 @@
         "strip-ansi": "^3.0.0"
       }
     },
+    "string-width-cjs": {
+      "version": "npm:string-width@4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
     "string.prototype.matchall": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
@@ -13806,6 +13735,21 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-ansi-cjs": {
+      "version": "npm:strip-ansi@6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        }
       }
     },
     "strip-bom": {
@@ -15047,6 +14991,67 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "wrap-ansi-cjs": {
+      "version": "npm:wrap-ansi@7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
           }
         }
       }


### PR DESCRIPTION
The script crashes due to
- .bin/npm not being available in all packages installed by devEnvSetup itself
- Trying to run tests for a meteor-desktop-localstorage package, even though that package isn't installed by devEnvSetup

The script also ignores the user's answer about whether to run tests or not (it always runs them, possibly after executing `finish()`). For convenience, it would also be nice to know what are the default answers to the script's questions.

This PR addresses these small problems, along with a rewrite of the related README section about "Developing meteor-desktop" and using devEnvSetup.

Note: The last two tests run by devEnvSetup, `npm run desktop -- build -b` and `npm run test-desktop` in meteor-desktop-test-app also fail, but I don't think this is caused by devEnvSetup itself and therefore is not addressed by this PR.

Tested with meteor-desktop 3.1.0.