### PR TITLE
Dynamically get preset-env version

### DIFF
--- a/lib/electronApp.js
+++ b/lib/electronApp.js
@@ -852,7 +852,7 @@ export default class ElectronApp {
         const uglifyingEnabled = 'uglify' in settings && !!settings.uglify;
 
         const preset = presetEnv({
-            version: '7.22.14',
+            version: require('../package.json').dependencies['@babel/preset-env'],
             assertVersion: () => { }
         }, { targets: { node: '14' } });
 

--- a/plugins/bundler/bundler.js
+++ b/plugins/bundler/bundler.js
@@ -814,7 +814,7 @@ class MeteorDesktopBundler {
                 babelPresetEnv = babelPresetEnv.default;
             }
             const preset = babelPresetEnv({
-                version: '7.22.14',
+                version: this.getPackageJsonField('dependencies')['@babel/preset-env'],
                 assertVersion: () => { }
             }, { targets: { node: '14' } });
 

--- a/plugins/bundler/bundler.js
+++ b/plugins/bundler/bundler.js
@@ -713,7 +713,6 @@ class MeteorDesktopBundler {
                     terser,
                     md5
                 } = deps);
-                console.log(deps);
             } catch (e) {
                 // Look at the declaration of StringPrototypeToOriginal for explanation.
                 String.prototype.to = StringPrototypeToOriginal; // eslint-disable-line


### PR DESCRIPTION
As discussed here: https://github.com/Meteor-Community-Packages/meteor-desktop/issues/12#issuecomment-1729618638