### PR TITLE
Fix/add desktop script

### DIFF
--- a/lib/scripts/addToScripts.js
+++ b/lib/scripts/addToScripts.js
@@ -13,7 +13,8 @@ function fail() {
 }
 
 const packageJsonPath = path.resolve(
-    path.join(__dirname, '..', '..', '..', '..', 'package.json')
+    // For registry installs, __dirname = node_modules/@meteor-community/meteor-desktop/dist/scripts
+    path.join(__dirname, '..', '..', '..', '..', '..', 'package.json')
 );
 
 addScript('desktop', 'meteor-desktop', packageJsonPath, fail);

--- a/lib/scripts/addToScripts.js
+++ b/lib/scripts/addToScripts.js
@@ -1,11 +1,13 @@
 /* eslint-disable no-console */
-import path from 'path';
-
 import addScript from './utils/addScript';
+
+const path = require('path');
+
 /**
  * This script adds a 'desktop' entry to 'scripts' in package.json. If the entry already exists
  * it leaves it untouched.
  */
+
 function fail() {
     console.error('[meteor-desktop] failed to add meteor-desktop to your package.json scripts, ' +
         'please add it manually as \'desktop\': \'meteor-desktop\'');


### PR DESCRIPTION
This should fix both the desktop script not being added to package.json anymore during normal installs (although I can't test without publishing) and the corresponding integration test. They were 2 separate issues. See commit messages for details.