### PR TITLE
Devrton: Remove all usage of and references to the obsolete package

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,6 @@
             "electron-debug",
             "rimraf",
             "process",
-            "devtron",
             "ava",
             "send",
             "meteor-desktop-test-suite"

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Documentation
         * [List of known plugins:](#list-of-known-plugins)
   * [Squirrel autoupdate support](#squirrel-autoupdate-support)
   * [Native modules support](#native-modules-support)
-  * [Devtron](#devtron)
   * [Testing desktop app and modules](#testing-desktop-app-and-modules)
   * [MD_LOG_LEVEL](#md_log_level)
   * [Packaging](#packaging)
@@ -238,7 +237,6 @@ field|description
 `version`|version of the desktop app
 `projectName`|this will be used as a `name` in the generated app's package.json
 `devTools`|whether to install and open `devTools`, set automatically to false when building with `--production`
-`devtron`|check whether to install [`devtron`](http://electron.atom.io/devtron/), set automatically to false when building with `--production`, [more](#devtron)
 `singleInstance`|sets the single instance mode - [more](https://github.com/electron/electron/blob/master/docs/api/app.md#appmakesingleinstancecallback)
 `desktopHCP`|whether to use `.desktop` hot code push module - [more](#desktophcp---desktop-hot-code-push)
 <sup>`desktopHCPIgnoreCompatibilityVersion`</sup>|ignore the `.desktop` compatibility version and install new versions even if they can be incompatible
@@ -489,9 +487,6 @@ not updated, nor checked for changes!
  in `.desktop` will not trigger rebuilds, in that case you need to make any
 change in `version` field in the `desktop.version` to trigger rebuild (this file is in the root of
 your project) - this can be any change like just adding random char to the hash
-- if your run a production build of your desktop app it will not receive updates from project run
- from `meteor` command unless you run it with `--production` - that is because development build
- has `devtron` added and therefore the `compatibilityVersion` is different  
 - after reload logs will no longer be shown in the console
 
 ## How to write plugins
@@ -536,14 +531,6 @@ https://github.com/ArekSredzki/electron-release-server
 
 This integration fully supports rebuilding native modules (npm packages with native node modules)
  against `Electron's` `node` version. The mechanism is enabled by default.
-
-## Devtron
-
-[`Devtron`](http://electron.atom.io/devtron/) is installed and activated by default. It is
-automatically removed when building with `--production`. As the communication between your Meteor
- app and the desktop side goes through IPC, this tool can be very handy because it can sniff on
- IPC messages.
-<kbd>![devtron IPC sniff](docs/devtron_ipc.gif)</kbd>
 
 ## Testing desktop app and modules
 

--- a/lib/desktop.js
+++ b/lib/desktop.js
@@ -225,7 +225,6 @@ export default class Desktop {
  * @property {string} name
  * @property {string} projectName
  * @property {boolean} devTools
- * @property {boolean} devtron
  * @property {boolean} desktopHCP
  * @property {Object} squirrel
  * @property {string} squirrel.autoUpdateFeedUrl

--- a/lib/electronAppScaffold.js
+++ b/lib/electronAppScaffold.js
@@ -31,7 +31,6 @@ export default class ElectronAppScaffold {
         };
 
         if (!this.$.env.isProductionBuild() || this.$.env.options.prodDebug) {
-            this.packageJson.dependencies.devtron = '1.4.0';
             this.packageJson.dependencies['electron-debug'] = '1.5.0';
         }
     }

--- a/scaffold/settings.json
+++ b/scaffold/settings.json
@@ -3,7 +3,6 @@
     "version": "0.0.1",
     "projectName": "MyMeteorApp",
     "devTools": true,
-    "devtron": true,
     "desktopHCP": true,
     "desktopHCPIgnoreCompatibilityVersion": false,
     "squirrel": {

--- a/skeleton/app.js
+++ b/skeleton/app.js
@@ -594,7 +594,7 @@ export default class App {
 
         this.webContents = this.window.webContents;
 
-        if (this.settings.devtron && !this.isProduction()) {
+        if (!this.isProduction()) {
             this.webContents.on('did-finish-load', () => {
                 // Print some fancy status to the console if in development.
                 this.webContents.executeJavaScript(`
@@ -684,9 +684,6 @@ export default class App {
                 this.emit('beforeLoadFinish');
                 this.window.show();
                 this.window.focus();
-                if (this.settings.devtron && !this.isProduction()) {
-                    this.webContents.executeJavaScript('Desktop.devtron.install()');
-                }
             }
         } else {
             this.l.debug('window already loaded');

--- a/skeleton/preload.js
+++ b/skeleton/preload.js
@@ -294,20 +294,11 @@ const Desktop = new (class {
 
 
 process.once('loaded', () => {
-    let devtron = null;
-
-    try {
-        devtron = require('devtron'); // eslint-disable-line global-require
-        global.__devtron = { require, process }; // eslint-disable-line no-underscore-dangle
-    } catch (e) {
-        // If that fails, then this is a production build and devtron is not available.
-    }
     if (process.env.NODE_ENV === 'test') {
         global.electronRequire = require;
         global.process = process;
     }
 
-    Desktop.devtron = devtron;
     Desktop.electron = [];
 
     exposedModules.forEach((module) => {

--- a/tests/fixtures/.desktop/settings.json
+++ b/tests/fixtures/.desktop/settings.json
@@ -3,7 +3,6 @@
     "version": "0.0.1",
     "projectName": "MyMeteorApp",
     "devTools": true,
-    "devtron": true,
     "desktopHCP": true,
     "desktopHCPIgnoreCompatibilityVersion": false,
     "autoUpdateFeedUrl": "http://127.0.0.1/update/:platform/:version",

--- a/tests/functional/desktop.test.js
+++ b/tests/functional/desktop.test.js
@@ -63,7 +63,7 @@ describe('desktop', () => {
             const logStub = new StubLog(MeteorDesktop.desktop, ['info']);
             MeteorDesktop.env.paths.desktop.root = paths.fixtures.desktop;
             const version = await MeteorDesktop.desktop.getHashVersion();
-            expect(version).to.be.equal('c18b45f899ee04cea7f5704e98d88d9ecf0239b9');
+            expect(version).to.be.equal('ab8e701a7b8951681479a95a9c1b47e2d3e784bb');
             logStub.restore();
         });
     });


### PR DESCRIPTION
As per title.

Note that I removed the following point from README -> desktopHCP -> Caveats:
> if your run a production build of your desktop app it will not receive updates from project run
 from `meteor` command unless you run it with `--production` - that is because development build
 has `devtron` added and therefore the `compatibilityVersion` is different  

The reason is that 1) the "issue" still seems to happen after removal of devrton (?) and 2) running meteor with `--production` doesn't work for me either, because changes in .desktop/ do not trigger a desktopHCP reload anyway. So it seems to me that this comment is outdated, but I may be wrong. Feel free to add a corrected text if applicable.