### PR TITLE
Don't SIGKILL Meteor when a desktop build terminates normally

### DIFF
--- a/lib/meteorApp.js
+++ b/lib/meteorApp.js
@@ -423,9 +423,9 @@ export default class MeteorApp {
             );
 
             // Kills the currently running meteor command.
-            function kill() {
+            function kill(signal = 'SIGKILL') {
                 sll('');
-                child.kill('SIGKILL');
+                child.kill(signal);
                 if (self.$.env.os.isWindows) {
                     windowsKill(child.pid);
                 }
@@ -435,7 +435,7 @@ export default class MeteorApp {
                 killTimeout = setTimeout(() => {
                     clearTimeoutsAndIntervals();
                     desiredExit = true;
-                    kill();
+                    kill('SIGTERM');
                     resolve();
                 }, 500);
             }


### PR DESCRIPTION
This solves, possibly among other things, the issue that when Meteor is started automatically by meteor-desktop, Mongo is not stopped after the build process terminates.