### PR TITLE
Watcher plugin fix: v3.1.1 should require bundler plugin v3.1.1

### DIFF
--- a/plugins/watcher/package.js
+++ b/plugins/watcher/package.js
@@ -16,7 +16,7 @@ Package.onUse(function onUse(api) {
     api.versionsFrom('METEOR@1.4.4.6');
     api.use('ecmascript');
     api.use([
-        'communitypackages:meteor-desktop-bundler@3.1.0',
+        'communitypackages:meteor-desktop-bundler@3.1.1',
     ], ['server'], {
         weak: true
     });


### PR DESCRIPTION
I think this is an omission in https://github.com/Meteor-Community-Packages/meteor-desktop/pull/13/commits/14e3692e6a52beb99759d24b652447b5f76923d7 "Version bump for 3.1.1 release". 