### PR TITLE
Integration tests: remove special plugins version handling for RCs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,11 +68,7 @@ class MeteorDesktop {
             this.log.error(`error while trying to read ${path.join(__dirname, 'package.json')}`, e);
             process.exit(1);
         }
-        if (process.env.PLUGIN_VERSION &&
-            (version.includes('rc') || version.includes('beta') || version.includes('alpha'))
-        ) {
-            version = process.env.PLUGIN_VERSION;
-        }
+
         return version;
     }
 

--- a/tests/integration/integration.test.js
+++ b/tests/integration/integration.test.js
@@ -101,8 +101,6 @@ function makeMandatoryPathsInBuilderSettingsAbsolute(settingJsonPath) {
     fs.writeFileSync(settingJsonPath, JSON.stringify(settingJson, null, 2));
 }
 
-process.env.PLUGIN_VERSION = '1.7.0';
-
 describe('desktop', () => {
     let MeteorDesktop;
 


### PR DESCRIPTION
As reported in https://github.com/Meteor-Community-Packages/meteor-desktop/pull/32#issuecomment-1747266347 and in https://github.com/Meteor-Community-Packages/meteor-desktop/pull/13#issuecomment-1748450031, integration tests fail for the currently published RC (release candidate) version:

```
While adding package communitypackages:meteor-desktop-watcher@=1.7.0:
error: no such version communitypackages:meteor-desktop-watcher@1.7.0

While adding package communitypackages:meteor-desktop-bundler@=1.7.0:
error: no such version communitypackages:meteor-desktop-bundler@1.7.0

ERROR electronApp: error while checking for required packages: Error: Error: adding packages failed
```

This is likely due to a piece of code which, for integration tests, deals with RC/beta/alpha versions in a special way. For such versions of the NPM package, the atmosphere plugins version is overwritten by an env var `PLUGIN_VERSION` set in `integration.test.js`.

I find this undocumented behavior a bit confusing. We could just change `PLUGIN_VERSION` to 3.1.1 in the code but the issue might happen again in the future. So I opted to just remove the code.

Another solution could be to keep the env var but not define it in `integration.test.js` by default, and just keep `if (process.env.PLUGIN_VERSION) version = process.env.PLUGIN_VERSION;` in `index.js`. And document that somewhere in README. But I'd recommend we simply try to keep the atmosphere and NPM package versions in sync.

What do you think?