### PR TITLE
Fix CI integration test

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
     "presets": [
         ["@babel/env", {
             "targets": {
-                "node": "12"
+                "node": "14"
             }
         }]
     ],

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
       - name: Install/Retrieve Meteor
         if: steps.files-cache.outputs.cache-hit != 'true'
-        run: curl https://install.meteor.com/?release=2.6 | /bin/sh
+        run: curl https://install.meteor.com/?release=2.6.1 | /bin/sh
       - name: Install NPM Dependencies
         if: steps.files-cache.outputs.cache-hit != 'true'
         run: meteor npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,69 +1,80 @@
-
 on:
+  pull_request:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
+
+env:
+  METEOR_VERSION: 2.6.1
 
 jobs:
   build:
     name: Build and Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        id: files-cache
-        with:
-         path: |
-           node_modules
-           dist/
-           ~/.meteor
-           /tmp/tests/.__tmp_int
-         key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-      - name: Install/Retrieve Meteor
-        if: steps.files-cache.outputs.cache-hit != 'true'
-        run: curl https://install.meteor.com/?release=2.6.1 | /bin/sh
-      - name: Install NPM Dependencies
-        if: steps.files-cache.outputs.cache-hit != 'true'
-        run: meteor npm ci
-
-  test:
-    needs: build
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    steps:
-     - uses: actions/checkout@v3
-     - name: Get Cache dependencies
-       uses: actions/cache@v3
-       id: files-cache
-       with:
-        path: |
-           node_modules
-           dist/
-           ~/.meteor
-           /tmp/tests/.__tmp_int
-        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-     - name: Unit Tests
-       run: ~/.meteor/meteor npm run test
-
-  test-integration:
-    needs: build
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get Cache dependencies
         uses: actions/cache@v3
         id: files-cache
         with:
-         path: |
-           node_modules
-           dist/
-           ~/.meteor
-           /tmp/tests/.__tmp_int
-         key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          path: |
+            dist
+            node_modules
+            /tmp/.__tmp_int
+            ~/.meteor
+            ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - name: Install/Retrieve Meteor
+        if: steps.files-cache.outputs.cache-hit != 'true'
+        run: curl https://install.meteor.com/?release=${{ env.METEOR_VERSION }} | /bin/sh
+      - name: Install NPM Dependencies
+        # Creates dist/ through postinstall->build script
+        if: steps.files-cache.outputs.cache-hit != 'true'
+        run: ~/.meteor/meteor npm ci
+      - name: Run build script
+        # Make sure dist/ is up-to-date when package-lock.json hasn't changed
+        if: steps.files-cache.outputs.cache-hit == 'true'
+        run: ~/.meteor/meteor npm run build
+
+  unit-tests:
+    needs: build
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get Cache dependencies
+        uses: actions/cache@v3
+        id: files-cache
+        with:
+          path: |
+            dist
+            node_modules
+            /tmp/.__tmp_int
+            ~/.meteor
+            ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - name: Run test script
+        run: ~/.meteor/meteor npm run test
+
+  integration-tests:
+    needs: build
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get Cache dependencies
+        uses: actions/cache@v3
+        id: files-cache
+        with:
+          path: |
+            dist
+            node_modules
+            /tmp/.__tmp_int
+            ~/.meteor
+            ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
       - run: ~/.meteor/meteor npm run prepare-integration-tests
-      - run: ~/.meteor/meteor npm run test-integration
+      - name: Run test-integration script (using Xvfb)
+        uses: coactions/setup-xvfb@v1
+        with: # needs full path to meteor
+          run: /home/runner/.meteor/meteor npm run test-integration

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,10 @@ skip_tags: true
 
 environment:
   matrix:
-    - nodejs_version: "12"
+    - nodejs_version: "14"
       test: "normal"
       platform: x64
-    - nodejs_version: "12"
+    - nodejs_version: "14"
       test: "integration"
       platform: x64
 
@@ -30,7 +30,7 @@ install:
   - ps: >-
       if ($env:test -eq "integration") {
         if ((Get-Command "meteor" -ErrorAction SilentlyContinue) -eq $null) {
-          choco install meteor --params "'/RELEASE:2.6'"
+          choco install meteor --params "'/RELEASE:2.6.1'"
         }
       }
   - ps: refreshenv

--- a/tests/integration/prepare.js
+++ b/tests/integration/prepare.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 
 const testsTmpPath = path.resolve(path.join(tempDir, '.__tmp_int'));
 
-const meteorVersion = '2.6';
+const meteorVersion = '2.6.1';
 
 shell.config.fatal = true;
 const appDir = path.join(testsTmpPath, 'test-desktop');


### PR DESCRIPTION
The automated integration tests should now pass on Github actions.

As [hypothesized](https://github.com/Meteor-Community-Packages/meteor-desktop/pull/13#issuecomment-1757029947), the problem was that `npm run test-integration` launches Electron and therefore needs a display to work properly, but the CI workflow runs on a headless Linux OS. Running the test-integration script through Xvfb (a virtual X11 display server) solved the issue.

I also made other minor improvements to the test workflow, see commit message details.

Related commit: Meteor and Node should now be 2.6.1 and 14 everywhere (it was still 2.6 and 12 in a few places).