### PR TITLE
Fix registering custom 'meteor' scheme

### DIFF
--- a/skeleton/app.js
+++ b/skeleton/app.js
@@ -32,7 +32,7 @@ export default class App {
             electron.protocol.registerStandardSchemes(['meteor'], { secure: true });
         } else {
             electron.protocol.registerSchemesAsPrivileged([
-                { scheme: 'meteor', privileges: { standard: true, secure: true, supportFetchAPI: true } }
+                { scheme: 'meteor', privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true } }
             ]);
         }
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?)
Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
-->
## What

Fixes registering the custom `meteor://` protocol which is used to serve assets locally.

<!-- Why are these changes necessary? -->
## Why

The [current implementation](https://github.com/Meteor-Community-Packages/meteor-desktop/blob/874b08b48f0067bb5b0c5c7ccd99d9392e687e65/skeleton/modules/localServer.js#L55) uses streams but does not specify the appropriate flag during registration.

From the Electron 17 docs (https://github.com/electron/electron/blob/v17.4.11/docs/api/protocol.md):

> Protocols that use streams (http and stream protocols) should set stream: true. The \<video\> and \<audio\> HTML elements expect protocols to buffer their responses by default. The stream flag configures those elements to correctly expect streaming responses.

Without specifying the `stream` flag, any larger files (>64kb of buffered data) in the `public` directory will not be loaded.
