### PR TITLE
Removing Node v18 constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "meteor-desktop": "dist/bin/cli.js"
   },
   "engines": {
-    "node": ">=12 <=18"
+    "node": ">=12"
   },
   "description": "Build a Meteor's desktop client with hot code push.",
   "main": "dist/index.js",


### PR DESCRIPTION
Meteor 3.0 uses node v22. We've updated our project from Meteor 2.16 and package works just fine with Meteor 3.0 and Node v22 #44 

@StorytellerCZ 